### PR TITLE
Revert "Adding support for building 32 bit boxes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,42 +19,32 @@ vagrant plugin install configure_networks
 ```
 
 - Add prebuild YunoHost boxes in vagrant
-*For 64 bit boxes*
 ```bash
-vagrant box add yunohost/jessie-amd64-stable https://build.yunohost.org/yunohost-jessie-amd64-stable.box
-vagrant box add yunohost/jessie-amd64-testing https://build.yunohost.org/yunohost-jessie-amd64-testing.box
-vagrant box add yunohost/jessie-amd64-unstable https://build.yunohost.org/yunohost-jessie-amd64-unstable.box
-```
-*For 32 bit boxes*
-```bash
-vagrant box add yunohost/jessie-i386-stable https://build.yunohost.org/yunohost-jessie-i386-stable.box
-vagrant box add yunohost/jessie-i386-testing https://build.yunohost.org/yunohost-jessie-i386-testing.box
-vagrant box add yunohost/jessie-i386-unstable https://build.yunohost.org/yunohost-jessie-i386-unstable.box
+vagrant box add yunohost/jessie-stable https://build.yunohost.org/yunohost-jessie-stable.box
+vagrant box add yunohost/jessie-testing https://build.yunohost.org/yunohost-jessie-testing.box
+vagrant box add yunohost/jessie-unstable https://build.yunohost.org/yunohost-jessie-unstable.box
 ```
 
 - Download the main Vagrant file
 ```bash
-wget https://raw.githubusercontent.com/Yunohost/Vagrantfile/master/Vagrantfile
+wget https://raw.githubusercontent.com/Yunohost/yunohost-vagrant/master/Vagrantfile
 ```
 
 - Run the box you need by calling vagrant up `DISTRIB`, example:
 ```bash
-vagrant up stable64
+vagrant up stable
 ```
 
-- `DISTRIB`: `stable64`, `testing64`, `unstable64`, `stable32`, `testing32` and `unstable32`.
+- `DISTRIB`: `stable`, `testing` and `unstable`.
 
 
 ## Associated ip
 
 To test on your computer, add this lines to your /etc/hosts .
 ```
-192.168.33.80 ynh-stable64.local
-192.168.33.81 ynh-testing64.local
-192.168.33.82 ynh-unstable64.local
-192.168.33.83 ynh-stable32.local
-192.168.33.84 ynh-testing32.local
-192.168.33.85 ynh-unstable32.local
+192.168.33.80 ynh-stable.local
+192.168.33.81 ynh-testing.local
+192.168.33.82 ynh-unstable.local
 ```
 
 VMs have different ip to be able to run twice.
@@ -66,19 +56,16 @@ After doing vagrant ssh run the postinstall by cli or into your browser
 
 ### CLI
 ```bash
-vagrant ssh stable64
-sudo yunohost tools postinstall -d ynh-stable64.local -p myAdminPassword
+vagrant ssh stable
+sudo yunohost tools postinstall -d ynh-stable.local -p myAdminPassword
 ```
 
 ### Browser
 Go to the coresponding domain in your browser and follow the instructions.
 
-- https://ynh-stable64.local for stable64
-- https://ynh-testing64.local for testing64
-- https://ynh-unstable64.local for unstable64
-- https://ynh-stable32.local for stable32
-- https://ynh-testing32.local for testing32
-- https://ynh-unstable32.local for unstable32
+- https://ynh-stable.local for stable
+- https://ynh-testing.local for testing
+- https://ynh-unstable.local for unstable
 
 ## How build these boxes yourself instead of using prebuild boxes ?
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,38 +15,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Force guest type, because YunoHost /etc/issue can't be tuned
   config.vm.guest = :debian
   
-  config.vm.define "stable64", primary: true do |stable|
-    stable.vm.box = "yunohost/jessie-amd64-stable"
+  config.vm.define "stable", primary: true do |stable|
+    stable.vm.box = "yunohost/jessie-stable"
     stable.vm.network :private_network, ip: "192.168.33.80"
   end
 
-  config.vm.define "testing64" do |testing|
-    testing.vm.box = "yunohost/jessie-amd64-testing"
+  config.vm.define "testing" do |testing|
+    testing.vm.box = "yunohost/jessie-testing"
     testing.vm.network :private_network, ip: "192.168.33.81"
   end
 
-  config.vm.define "unstable64" do |unstable|
-    unstable.vm.box = "yunohost/jessie-amd64-unstable"
+  config.vm.define "unstable" do |unstable|
+    unstable.vm.box = "yunohost/jessie-unstable"
     unstable.vm.network :private_network, ip: "192.168.33.82"
   end
   
   ### START AUTOMATIC YNH-DEV ZONE ###
   ### END AUTOMATIC YNH-DEV ###
 
-
-  config.vm.define "stable32" do |stable|
-    stable.vm.box = "yunohost/jessie-i386-stable"
-    stable.vm.network :private_network, ip: "192.168.33.83"
-  end
-
-  config.vm.define "testing32" do |testing|
-    testing.vm.box = "yunohost/jessie-i386-testing"
-    testing.vm.network :private_network, ip: "192.168.33.84"
-  end
-
-  config.vm.define "unstable32" do |unstable|
-    unstable.vm.box = "yunohost/jessie-i386-unstable"
-    unstable.vm.network :private_network, ip: "192.168.33.85"
-  end
 
 end

--- a/prebuild/README.md
+++ b/prebuild/README.md
@@ -2,15 +2,8 @@
 
 ## Get Debian base boxes
 
-### For the 64 bit box
-
 ```bash
 vagrant box add debian/contrib-jessie64
-```
-### For the 32 bit box
-
-```bash
-vagrant box add bento/debian-8.6-i386
 ```
 
 *Note:* You can only add Jessie base box as Wheezy support is now discontinued for YunoHost
@@ -25,24 +18,23 @@ wget https://raw.githubusercontent.com/YunoHost/Vagrantfile/master/prebuild/Vagr
 
 ## Run your homemade boxes
 
-Run the box you need by calling `vagrant up DEBIAN_CODENAME-ARCHITECTURE-YUNOHOST_VERSION`
+Run the box you need by calling `vagrant up DEBIAN_CODENAME-YUNOHOST_VERSION`
 
 ```bash
-vagrant up jessie-amd64-stable
+vagrant up jessie-stable
 ```
 
 - `DEBIAN_CODENAME`: Only `jessie` for now.
-- `ARCHITECTURE`: `i386` and `amd64` (32 or 64 bits).
 - `DISTRIB`: `stable`, `testing` and `unstable`.
 
-You can now log into your box with `vagrant ssh jessie-amd64-stable`
+You can now log into your box with `vagrant ssh jessie-stable`
 
 ## Package your own boxes
 
 You can package it to use it more quickly later:
 
 ```bash
-vagrant up jessie-amd64-stable
-vagrant package jessie-amd64-stable  --output ./my-yunohost-stable.box
+vagrant up jessie-stable
+vagrant package jessie-stable  --output ./my-yunohost-stable.box
 vagrant box add my-yunohost/stable ./my-yunohost-stable.box
 ```

--- a/prebuild/Vagrantfile
+++ b/prebuild/Vagrantfile
@@ -37,13 +37,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant"
   # Force guest type, because YunoHost /etc/issue can be tuned
   config.vm.guest = :debian
-  # Force first network device to be cable connected, not connected by default on Virtualbox
-  config.vm.provider "virtualbox" do |vb|
-    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
-  end
   
-  # Debian Jessie 64 bits with YunoHost stable release
-  config.vm.define "jessie-amd64-stable", primary: true do |stable|
+  # Debian Jessie with YunoHost stable release
+  config.vm.define "jessie-stable", primary: true do |stable|
     stable.vm.box = "debian/contrib-jessie64"
     stable.vm.provision "shell" do |s|
       s.inline = $script
@@ -52,8 +48,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     stable.vm.network :private_network, ip: "192.168.33.80"
   end
 
-  # Debian Jessie 64 bits with YunoHost testing release
-  config.vm.define "jessie-amd64-testing" do |testing|
+  # Debian Jessie with YunoHost testing release
+  config.vm.define "jessie-testing" do |testing|
     testing.vm.box = "debian/contrib-jessie64"
     testing.vm.provision "shell" do |s|
       s.inline = $script
@@ -62,44 +58,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     testing.vm.network :private_network, ip: "192.168.33.81"
   end
 
-  # Debian Jessie 64 bits with YunoHost unstable (nightly) release
-  config.vm.define "jessie-amd64-unstable" do |unstable|
+  # Debian Jessie with YunoHost unstable (nightly) release
+  config.vm.define "jessie-unstable" do |unstable|
     unstable.vm.box = "debian/contrib-jessie64"
     unstable.vm.provision "shell" do |s|
       s.inline = $script
       s.args   = "'unstable'"
     end
     unstable.vm.network :private_network, ip: "192.168.33.82"
-  end
-
-  # Debian Jessie 32 bits with YunoHost stable release
-  config.vm.define "jessie-i386-stable" do |stable|
-    stable.vm.box = "bento/debian-8.6-i386"
-    stable.vm.provision "shell" do |s|
-      s.inline = $script
-      s.args   = "'stable'"
-    end
-    stable.vm.network :private_network, ip: "192.168.33.83"
-  end
-
-  # Debian Jessie 32 bits with YunoHost testing release
-  config.vm.define "jessie-i386-testing" do |testing|
-    testing.vm.box = "bento/debian-8.6-i386"
-    testing.vm.provision "shell" do |s|
-      s.inline = $script
-      s.args   = "'testing'"
-    end
-    testing.vm.network :private_network, ip: "192.168.33.84"
-  end
-
-  # Debian Jessie 32 bits with YunoHost unstable (nightly) release
-  config.vm.define "jessie-i386-unstable" do |unstable|
-    unstable.vm.box = "bento/debian-8.6-i386"
-    unstable.vm.provision "shell" do |s|
-      s.inline = $script
-      s.args   = "'unstable'"
-    end
-    unstable.vm.network :private_network, ip: "192.168.33.85"
   end
 
 end

--- a/prebuild/prebuild.sh
+++ b/prebuild/prebuild.sh
@@ -2,36 +2,28 @@
 
 DEBIAN_VERSION="jessie"
 YNH_VERSION=$1
-ARCH=${2:-"amd64"}
-OUTDIR=${3:-/tmp}
 case $YNH_VERSION in
     stable|testing|unstable) echo "Building YunoHost $YNH_VERSION box.";;
-    --help|-h) echo "./prebuid.sh <ynh-version> [arch] [outdir]. ynh-version could be stable, testing or unstable. arch could be i386 or amd64 (amd64 by default). outdir is /tmp by default.";exit 0;;
+    --help|-h) echo "./prebuid.sh <ynh-version>. ynh-version could be stable, testing or unstable.";exit 0;;
     *)             echo "Unknown YunoHost version: $YNH_VERSION";exit 1;;
 esac
 
-case $ARCH in
-    i386) echo "Building a 32 bit box.";;
-    amd64) echo "Building a 64 bit box.";;
-    *) echo "Unknow architecture $ARCH. Exiting...";exit 1;;
-esac
-
 # Compute box name
-BOX="$DEBIAN_VERSION-$ARCH-$YNH_VERSION"
+BOX="$DEBIAN_VERSION-$YNH_VERSION"
 
 # Create box
 vagrant up $BOX
 
 # Package box
-vagrant package $BOX  --output $OUTDIR/yunohost-$BOX.box
+vagrant package $BOX  --output /tmp/yunohost-$BOX.box
 
 # Add box
-vagrant box add "yunohost/$BOX" $OUTDIR/yunohost-$BOX.box
+vagrant box add "yunohost/$BOX" /tmp/yunohost-$BOX.box
 
 # Destroy current box
 vagrant destroy $BOX
 
 # User message, and exit
 echo ""
-echo "Your Vagrant box was packaged to $OUTDIR/yunohost-$BOX.box"
+echo "Your Vagrant box was packaged to /tmp/yunohost-$BOX.box"
 exit


### PR DESCRIPTION
Hello,

I'm sorry I have to totally revert this previous PR but it totally break [`ynh-dev`](https://github.com/yunohost/ynh-dev/) and this breaks the dev cycle which is not really acceptable. This is not a "the code is bad we are never going to do that" but "we need to step back one feet ahead then fix the problems encountered".

List of problems I've encountered so far:

* renaming {stable,testing,unstable} to {stable,testing,unstable}64 breaks `ynh-dev` which has not been migrated
* `ynh-dev` can be migrated but this will break EVERY already in place `ynh-dev` which I don't consider to be acceptable, I think that we need to keep the {stable,testing,unstable} name valid for this reason
* the new url to other box simply doesn't exist which is really weird :confused: 

Like, those urls which are used doesn't exists:

* https://atlas.hashicorp.com/yunohost/boxes/jessie-i386-unstable
* https://atlas.hashicorp.com/yunohost/boxes/jessie-i386-testing
* https://atlas.hashicorp.com/yunohost/boxes/jessie-i386-stable
* https://atlas.hashicorp.com/yunohost/boxes/jessie-amd64-unstable
* https://atlas.hashicorp.com/yunohost/boxes/jessie-amd64-testing
* https://atlas.hashicorp.com/yunohost/boxes/jessie-amd64-stable

@rokaz or @zamentur, have you forgot to upload the new boxes?

The old urls still work:

* https://atlas.hashicorp.com/yunohost/boxes/jessie-unstable
* https://atlas.hashicorp.com/yunohost/boxes/jessie-testing
* https://atlas.hashicorp.com/yunohost/boxes/jessie-stable

Due to a broken production environment for everyone who is trying to uses `ynh-dev` (creating new env or new box simply doesn't work anymore), I'm merging this PR immediately and I suggest @rokaz, @zamentur or anyone else interested in fixing this (very interesting) work about 32 bits boxes in a new pull request (I don't have the time right now to do that). Sorry for the abrupt mesure but I think that the circumstances justify it, I really hope that no one takes that personally.

Kind regards,