### PR TITLE
Refactor build box compat libvirt

### DIFF
--- a/prebuild/README.md
+++ b/prebuild/README.md
@@ -1,13 +1,5 @@
 # Build your own YunoHost Vagrant box
 
-## Get Debian base boxes
-
-```bash
-vagrant box add debian/contrib-jessie64
-```
-
-*Note:* You can only add Jessie base box as Wheezy support is now discontinued for YunoHost
-
 ## Build YunoHost boxes
 
 Download the vagrant file to build from debian boxes
@@ -18,23 +10,30 @@ wget https://raw.githubusercontent.com/YunoHost/Vagrantfile/master/prebuild/Vagr
 
 ## Run your homemade boxes
 
-Run the box you need by calling `vagrant up DEBIAN_CODENAME-YUNOHOST_VERSION`
+Run the box you need by calling `vagrant up DEBIAN_CODENAME`
 
 ```bash
-vagrant up jessie-stable
+YUNOHOST_VERSION=unstable vagrant up stretch
 ```
 
-- `DEBIAN_CODENAME`: Only `jessie` for now.
-- `DISTRIB`: `stable`, `testing` and `unstable`.
+- `DEBIAN_CODENAME`: `stretch` or `jessie` for now.
+- `YUNOHOST_VERSION`: `stable`, `testing` and `unstable`.
 
-You can now log into your box with `vagrant ssh jessie-stable`
+You can now log into your box with `vagrant ssh stretch`
 
 ## Package your own boxes
 
 You can package it to use it more quickly later:
 
 ```bash
-vagrant up jessie-stable
-vagrant package jessie-stable  --output ./my-yunohost-stable.box
-vagrant box add my-yunohost/stable ./my-yunohost-stable.box
+vagrant up stretch
+vagrant package stretch --output ./yunohost-unstable-stretch.box
+vagrant box add yunohost/unstable ./yunohost-unstable-stretch.box
 ```
+
+
+### For libvirt provider
+
+* You need to use vagrant-libvirt master (build from source)
+
+`VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS="defaults,-ssh-userdir,-ssh-hostkeys,-lvm-uuids" vagrant package stretch --output ./yunohost-unstable-stretch.box`

--- a/prebuild/README.md
+++ b/prebuild/README.md
@@ -36,4 +36,16 @@ vagrant box add yunohost/unstable ./yunohost-unstable-stretch.box
 
 * You need to use vagrant-libvirt master (build from source)
 
-`VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS="defaults,-ssh-userdir,-ssh-hostkeys,-lvm-uuids" vagrant package stretch --output ./yunohost-unstable-stretch.box`
+1. `git clone https://github.com/vagrant-libvirt/vagrant-libvirt.git`
+1. `cd vagrant-libvirt`
+1. `VAGRANT_VERSION=v2.2.6 rake build`
+1. `vagrant plugin install pkg/vagrant-libvirt-0.0.45.gem`
+
+Then
+
+1. `vagrant up stretch`
+1. `VAGRANT_LIBVIRT_VIRT_SYSPREP_OPERATIONS="defaults,-ssh-userdir,-ssh-hostkeys,-lvm-uuids" vagrant package stretch --output ./yunohost-unstable-stretch.box`
+1. `vagrant box remove yunohost/unstable`
+1. Be sure to remove a old one if you have `sudo virsh vol-delete yunohost-VAGRANTSLASH-unstable_vagrant_box_image_0.img --pool default`
+1. `vagrant box add ./yunohost-unstable-stretch.box --name yunohost/unstable`
+

--- a/prebuild/Vagrantfile
+++ b/prebuild/Vagrantfile
@@ -3,6 +3,7 @@
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
+YUNOHOST_VERSION_DEFAULT = "unstable"
 
 $script = <<SCRIPT
 export DEBIAN_FRONTEND=noninteractive
@@ -19,9 +20,9 @@ echo -e "yunohost\nyunohost" | sudo passwd root
 export SUDO_FORCE_REMOVE=yes
 
 # Upgrade guest (done in install script)
-sudo apt-get update
-sudo apt-get -y --force-yes upgrade
-sudo apt-get -y --force-yes dist-upgrade
+#sudo apt-get update
+#sudo apt-get -y --force-yes upgrade
+#sudo apt-get -y --force-yes dist-upgrade
 
 # Install YunoHost
 wget https://raw.githubusercontent.com/YunoHost/install_script/stretch/install_yunohost -q -O /tmp/install_yunohost
@@ -29,6 +30,10 @@ sudo bash /tmp/install_yunohost -a -d $1
 
 # Cleanup
 sudo apt-get clean -y
+
+# Reset SSH key for vagrant user
+wget https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub -q -O /home/vagrant/.ssh/authorized_keys
+
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -38,24 +43,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 #  # Force guest type, because YunoHost /etc/issue can be tuned
 #  config.vm.guest = :debian
 
-  # Debian Jessie with YunoHost unstable (nightly) release
-  config.vm.define "jessie-unstable" do |unstable|
-    unstable.vm.box = "debian/contrib-jessie64"
-    unstable.vm.provision "shell" do |s|
+  # Debian Jessie with YunoHost release
+  config.vm.define "jessie" do |jessie|
+    jessie.vm.box = "debian/contrib-jessie64"
+    jessie.vm.provision "shell" do |s|
       s.inline = $script
-      s.args   = "'unstable'"
+      s.args   = "'" + ( ENV['YUNOHOST_VERSION'] || YUNOHOST_VERSION_DEFAULT )  + "'"
     end
-    unstable.vm.network :private_network, ip: "192.168.33.82"
+    jessie.vm.network :private_network, ip: "192.168.33.82"
   end
 
-  # Debian Stretch with YunoHost unstable (nightly) release
-  config.vm.define "stretch-unstable" do |unstable|
-    unstable.vm.box = "debian/stretch64"
-    unstable.vm.provision "shell" do |s|
+  # Debian Stretch with YunoHost release
+  config.vm.define "stretch" do |stretch|
+    stretch.vm.box = "debian/stretch64"
+    stretch.vm.provision "shell" do |s|
       s.inline = $script
-      s.args   = "'unstable'"
+      s.args   = "'" + ( ENV['YUNOHOST_VERSION'] || YUNOHOST_VERSION_DEFAULT )  + "'"
     end
-    unstable.vm.network :private_network, ip: "192.168.33.93"
+    stretch.vm.network :private_network, ip: "192.168.33.93"
   end
 
 end


### PR DESCRIPTION
* Add Libvirt support
* Clean the Vagrantfile for building the box
* Inject the default SSH Vagrant key (wiped on first boot)

## Thoughts
* We might drop support for jessie ? Pretty sure we can't build these anymore
* I think there is still a issue about the ssh host key not being regenerate at boot.