### PR TITLE
Create a Debian Buster image for YunoHost

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,6 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-
   # Default folder sharing
   config.vm.synced_folder ".", "/vagrant", id: "vagrant-root",
   owner: "root",
@@ -14,21 +13,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Force guest type, because YunoHost /etc/issue can't be tuned
   config.vm.guest = :debian
-
-  config.vm.define "unstable" do |unstable|
-    unstable.vm.box = "yunohost/jessie-unstable"
-    unstable.vm.box_url = "https://build.yunohost.org/yunohost-unstable.box"
-    unstable.vm.network :private_network, ip: "192.168.33.82"
+  
+  # Base box
+  config.define = "yunohost-debian10"
+  config.vm.box = "debian/buster64"
+  
+  # Install yunohost on the base image
+  # They can be re-run with `vagrant provision --provision-with ynh-core`
+  config.vm.provision "ynh-core", type: "shell" do |shell|
+    shell.path = "https://install.yunohost.org/buster"
+    shell.sha256 = "830f59f819ba62bc342df1e30359621f64d83b0db257095f07a46d6cd57e0d78"
+    shell.args = ["-a"]
   end
-
-  config.vm.define "stretch-unstable" do |stretch_unstable|
-    stretch_unstable.vm.box = "yunohost/stretch-unstable"
-    stretch_unstable.vm.box_url = "https://build.yunohost.org/yunohost-stretch-unstable.box"
-    stretch_unstable.vm.network :private_network, ip: "192.168.33.83"
-  end
+  
+  # Run postinstall commands
+  # They can be re-run with `vagrant provision --provision-with ynh-postinstall`
+  config.vm.provision "ynh-postinstall", type: "shell", inline: "yunohost tools postinstall -d yunohost.local -p vagrantboxadmin"
 
   ### START AUTOMATIC YNH-DEV ZONE ###
   ### END AUTOMATIC YNH-DEV ###
-
-
 end


### PR DESCRIPTION
This is useful to locally test the packaging of an app.

Next step is to create a reusable box out of it:

```bash
vagrant package --output yunohost-debian10.box
```

Could then be [uploaded manually or automated with curl](https://www.vagrantup.com/vagrant-cloud/boxes/create).